### PR TITLE
 - Fixes quanah/net-ldapapi#3: ldap_set_rebind_proc XS being called with...

### DIFF
--- a/net-ldapapi/trunk/LDAPapi.pm
+++ b/net-ldapapi/trunk/LDAPapi.pm
@@ -1821,10 +1821,10 @@ sub set_rebind_proc
     my ($self, @args) = @_;
     my ($status);
 
-    my ($rebindproc) = $self->rearrange(['REBINDPROC'], @args);
+    my ($rebindproc, $params) = $self->rearrange(['REBINDPROC', 'PARAMS'], @args);
 
     if( ref($rebindproc) eq "CODE" ) {
-        $status = ldap_set_rebind_proc($self->{"ld"}, $rebindproc);
+        $status = ldap_set_rebind_proc($self->{"ld"}, $rebindproc, $params);
     } else {
         croak("REBINDPROC is not a CODE Reference");
     }


### PR DESCRIPTION
Function prototype in LDAPapi.xs is:

void
ldap_set_rebind_proc(ld,rebind_function,args)

LDAPapi.xs calling as:

ldap_set_rebind_proc(ld,rebind_function)

Fixed by:
- Adding PARAMS to set_rebind_proc()
- Passing to ldap_set_rebind_proc()
