### PR TITLE
 - Fixes quanah/net-ldapapi#8: search_s() clobbers ATTRS parameter

### DIFF
--- a/net-ldapapi/trunk/LDAPapi.pm
+++ b/net-ldapapi/trunk/LDAPapi.pm
@@ -1641,7 +1641,7 @@ sub search_s
 
     croak("No Filter Passed as Argument 3") if ($filter eq "");
 
-    if( !defined($attrs) == undef ) {
+    if( !defined($attrs) ) {
         my @null_array = ();
         $attrs = \@null_array;
     }


### PR DESCRIPTION
Output after this change:

```
===== SEARCH
dn: cn=Full,ou=Users,o=Test Data,c=nz
cn: Full
===== SEARCH_S
dn: cn=Full,ou=Users,o=Test Data,c=nz
cn: Full
```
