### PR TITLE
 - Fixes quanah/net-ldapapi#20: ldap_result() doesn't honour passed t…

### DIFF
--- a/net-ldapapi/trunk/LDAPapi.pm
+++ b/net-ldapapi/trunk/LDAPapi.pm
@@ -840,6 +840,10 @@ sub next_changed_entries {
 
     @entries = ();
 
+    if ($self->{'status'} == 0) { # ldap_result return 0 = timeout
+        return @entries;
+    }
+    
     $asn = $self->{"asn"};
 
     while( $msg = $self->result_message ) {

--- a/net-ldapapi/trunk/LDAPapi.xs
+++ b/net-ldapapi/trunk/LDAPapi.xs
@@ -826,7 +826,7 @@ ldap_result(ld, msgid, all, timeout, result)
            tv_timeout->tv_sec = atof(timeout);
            tv_timeout->tv_usec = 0;
         }
-        RETVAL = ldap_result(ld, msgid, all, NULL, &result);
+        RETVAL = ldap_result(ld, msgid, all, tv_timeout, &result);
     }
     OUTPUT:
     RETVAL


### PR DESCRIPTION
Sample code in #20 no longer blocks indefinitely.

Related bug within next_changed_events fixed with this push as well.
