### PR TITLE
 - Fixes quanah/net-ldapapi#28: Server control responses get eaten after a NULL character in the berval

### DIFF
--- a/net-ldapapi/trunk/LDAPapi.xs
+++ b/net-ldapapi/trunk/LDAPapi.xs
@@ -1168,12 +1168,12 @@ ldap_control_oid(control)
     RETVAL
 
 
-char *
+SV *
 ldap_control_berval(control)
     LDAPControl * control
     CODE:
     {
-        RETVAL = control->ldctl_value.bv_val;
+        RETVAL = newSVpv(control->ldctl_value.bv_val, control->ldctl_value.bv_len);
     }
     OUTPUT:
     RETVAL


### PR DESCRIPTION
New output from sample program with this change applied:

```
===== Server Side Sort and Virtual List View
 + Loading ASN for SortKeyList, SortResult, VirtualListViewRequest, VirtualListViewResponse
 + Constructing Server Side Sort control
sss ctrl berval =
[0000]   30 13 30 11  04 02 73 6E  80 08 32 2E  35 2E 31 33   0.0. ..sn ..2. 5.13
[0010]   2E 33 81 01  FF                                      .3.. .
 + Constructing Virtual List View control
vlv ctrl berval =
[0000]   30 0E 02 01  01 02 01 03  A0 06 02 01  01 02 01 00   0... .... .... ....
 + Searching for results
 + Parsing first entry
result = {
  'matcheddn' => undef,
  'referrals' => [],
  'errmsg' => undef,
  'serverctrls' => [
                     32330960,
                     32336928
                   ],
  'errcode' => 0
}
 + Reading result-scope server response controls
 + Response control 32330960 [1.2.840.113556.1.4.474]
berval =
[0000]   30 03 0A 01  00                                      0... .
 + Parsing SSS response berval
 + Response control 32336928 [2.16.840.1.113730.3.4.10]
berval =
[0000]   30 14 02 01  01 02 02 7E  B0 0A 01 00  04 08 E0 FE   0... ...~ .... ....
[0010]   4A 7C 67 7F  00 00                                   J| ..
 + Parsing VLV response berval
 + Search results
dn: cn=Test User,ou=Users,o=Test Data,c=nz
dn: cn=Ani Odey,ou=Users,o=Test Data,c=nz
dn: cn=Vevelyn Odette,ou=Users,o=Test Data,c=nz
dn: cn=Donyetta Odett,ou=Users,o=Test Data,c=nz
```
