### PR TITLE
- Fixes quanah/net-ldapapi#40: Server control requests get eaten after a NULL character in the berval

### DIFF
--- a/LDAPapi.xs
+++ b/LDAPapi.xs
@@ -1863,8 +1863,7 @@ ldap_create_control(oid, bv_val, bv_len, iscritical, ctrlp)
         LDAPControl *ctrl = malloc(sizeof(LDAPControl));
 
         ctrl->ldctl_oid          = ber_strdup(oid);
-        ctrl->ldctl_value.bv_val = ber_strdup(bv_val);
-        ctrl->ldctl_value.bv_len = bv_len;
+        ber_mem2bv(bv_val, bv_len, 1, &ctrl->ldctl_value);
         ctrl->ldctl_iscritical   = iscritical;
 
         ctrlp = ctrl;

--- a/t/features/server_controls.feature
+++ b/t/features/server_controls.feature
@@ -6,13 +6,16 @@ Feature: Using server controls to control results
  Background:
    Given a usable Net::LDAPapi class
 
- Scenario: Can use the Server Side Sort control
+ Scenario: Can use the Server Side Sort control and Virtual List View Control
    Given a Net::LDAPapi object that has been connected to the LDAP server
    And the server side sort control definition
+   And the virtual list view control definition
    When I've bound with default authentication to the directory
    And I've created a server side sort control
-   And I've searched for records with scope LDAP_SCOPE_SUBTREE, with server control server side sort
+   And I've created a virtual list view control
+   And I've searched for records with scope LDAP_SCOPE_SUBTREE, with server controls server side sort and virtual list view
    Then the search result is LDAP_SUCCESS
    And the search count matches
    And using next_entry for each entry returned the dn and all attributes using next_attribute are valid
    And the server side sort control was successfully used
+   And the virtual list view control was successfully used

--- a/t/features/step_definitions/search_steps.pl
+++ b/t/features/step_definitions/search_steps.pl
@@ -14,7 +14,7 @@ When qr/I've (asynchronously )?searched for records with scope ([^, ]+)(?:, with
   my $scope = $2;
   my $timeout = $6;
 
-  my @server_ctrls = $3 ? map { S->{'server_controls'}{$_} } split(/(?:,|and)\s*/, $3) : undef;
+  my @server_ctrls = $3 ? map { S->{'server_controls'}{$_} } split(/\s*(?:,|and)\s*/, $3) : undef;
 
   my $func = "search_ext_s";
   if ($async) {
@@ -31,7 +31,7 @@ When qr/I've (asynchronously )?searched for records with scope ([^, ]+)(?:, with
     -filter => $TestConfig{'search'}{'filter'},
     -attrs => \@{['cn']},
     -attrsonly => 0,
-    -sctrls => @server_ctrls,
+    -sctrls => [@server_ctrls],
     -timeout => $timeout);
 };
 

--- a/t/features/step_definitions/server_controls_steps.pl
+++ b/t/features/step_definitions/server_controls_steps.pl
@@ -34,6 +34,35 @@ ASN
   }
 };
 
+Given qr/the virtual list view control definition/i, sub { 
+  if (!defined(S->{'asn'}{'virtual list view'})) {
+    S->{'asn'}{'virtual list view'} = Convert::ASN1->new;
+  
+    S->{'asn'}{'virtual list view'}->prepare(<<ASN) or die "prepare: ", S->{'asn'}{'virtual list view'}->error;
+  
+  VirtualListViewRequest ::= SEQUENCE {
+    beforeCount    INTEGER,
+    afterCount     INTEGER,
+    target       CHOICE {
+      byOffset        [0] SEQUENCE {
+        offset          INTEGER,
+        contentCount    INTEGER
+      },
+      greaterThanOrEqual [1] OCTET STRING
+    },
+    contextID OCTET STRING OPTIONAL
+  }
+
+  VirtualListViewResponse ::= SEQUENCE {
+    targetPosition    INTEGER,
+    contentCount     INTEGER,
+    virtualListViewResult ENUMERATED,
+    contextID OCTET STRING OPTIONAL
+  }
+
+ASN
+  }
+};
 
 When qr/I've created a server side sort control/i, sub {
   my $sss = S->{'asn'}{'server side sort'}->find('SortKeyList');
@@ -45,7 +74,20 @@ When qr/I've created a server side sort control/i, sub {
     -berval => $sss_berval,
   );
 
-  push(@{S->{'server_controls'}{'server side sort'}}, $sss_ctrl);
+  S->{'server_controls'}{'server side sort'} = $sss_ctrl;
+};
+
+When qr/I've created a virtual list view control/i, sub {
+  my $vlv = S->{'asn'}{'virtual list view'}->find('VirtualListViewRequest');
+
+  my $vlv_berval = $vlv->encode($TestConfig{'server_controls'}{'vlv'}) or die S->{'asn'}{'virtual list view'}->error;
+
+  my $vlv_ctrl = S->{'object'}->create_control(
+    -oid => '2.16.840.1.113730.3.4.9',
+    -berval => $vlv_berval,
+  );
+
+  S->{'server_controls'}{'virtual list view'} = $vlv_ctrl;
 };
 
 Then qr/the server side sort control was successfully used/i, sub {
@@ -68,5 +110,27 @@ Then qr/the server side sort control was successfully used/i, sub {
 
   is(ldap_err2string($result->{'sortResult'}), ldap_err2string(LDAP_SUCCESS), "Does server side sort result code match?");        
 };
+
+Then qr/the virtual list view control was successfully used/i, sub {
+  my $vlv_response = S->{'asn'}{'virtual list view'}->find('VirtualListViewResponse');
+
+  my $berval = undef;
+  
+  foreach my $ctrl (@{S->{'cache'}{'serverctrls'}}) {
+    my $ctrl_oid = S->{'object'}->get_control_oid($ctrl);
+    
+    if ($ctrl_oid eq '2.16.840.1.113730.3.4.10') {
+      $berval = S->{'object'}->get_control_berval($ctrl);
+      last;
+    }
+  }
+  
+  isnt($berval, undef, "Was a berval returned?");
+  
+  my $result = $vlv_response->decode($berval) || ok(0, $vlv_response->error);
+
+  is(ldap_err2string($result->{'virtualListViewResult'}), ldap_err2string(LDAP_SUCCESS), "Does virtual list view result code match?");        
+};
+
 
 1;

--- a/t/test-config.pl
+++ b/t/test-config.pl
@@ -90,6 +90,16 @@ our %TestConfig = (
         'reverseOrder' => 1
       },
     ],
+    'vlv' => {
+      'beforeCount' => 0,
+      'afterCount' => 3,
+      'target' => {
+        'byOffset' => {
+          'offset' => 1,
+          'contentCount' => 0
+        }
+      }
+    },
   },
   'compare' => {
     'entry_attribute' => 'cn', 


### PR DESCRIPTION
- Fixes quanah/net-ldapapi#40: Server control requests get eaten after a NULL character in the berval
- Adds Virtual List View to the server control testing with beforeCount set to 0 to provide a regression test for quanah/net-ldapapi#40
