### PR TITLE
Some memory cleanup

### DIFF
--- a/LDAPapi.pm
+++ b/LDAPapi.pm
@@ -886,6 +886,7 @@ sub next_changed_entries {
                     # save the cookie
 										save_cookie($cookie, $self->{"cookie"});
                 }
+                ldap_control_free($ctrl);
             }
 
         } elsif( $msgtype eq $self->LDAP_RES_INTERMEDIATE ) {


### PR DESCRIPTION
Only plugs a couple of small leaks, more remain. The big problem is
in passing complex structures like LDAPmessages and Controls back to
the caller - the current code only replaces the outer C structure
with perl structures, but doesn't tell perl anything about the other
sub-structures inside. Those are still leaking.

Partially fixes #51 