### PR TITLE
Test suite - Fixes for test isolation

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -37,6 +37,7 @@ t/features/step_definitions/compare_steps.pl
 t/features/compare.feature
 t/features/modify.feature
 t/features/syncrepl.feature
+t/features/syncrepl_cancel.feature
 t/features/rename.feature
 t/features/add.feature
 t/features/server_controls.feature

--- a/t/features/add.feature
+++ b/t/features/add.feature
@@ -17,7 +17,9 @@ Feature: Adding entries to the directory
  Scenario: Can asynchronously add a new entry to the directory
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with default authentication to the directory
-   And a test container has been created
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
+   And the bind result is LDAP_SUCCESS
+   When a test container has been created
    And I've asynchronously added a new entry to the directory
    Then after waiting for all results, the new entry result message type is LDAP_RES_ADD
    And the new entry result is LDAP_SUCCESS

--- a/t/features/bind.feature
+++ b/t/features/bind.feature
@@ -24,17 +24,17 @@ Feature: Binding to the directory
  Scenario: Can asynchronously bind anonymously
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with anonymous authentication to the directory
-   Then the bind result message type is LDAP_RES_BIND
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
    And the bind result is LDAP_SUCCESS
 
  Scenario: Can asynchronously bind with simple authentication
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with simple authentication to the directory
-   Then the bind result message type is LDAP_RES_BIND
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
    And the bind result is LDAP_SUCCESS
 
 # Scenario: Can asynchronously bind with sasl authentication
 #   Given a Net::LDAPapi object that has been connected to the ldapi LDAP server
 #   When I've asynchronously bound with sasl authentication to the directory
-#   Then the bind result message type is LDAP_RES_BIND
+#   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
 #   And the bind result is LDAP_SUCCESS

--- a/t/features/compare.feature
+++ b/t/features/compare.feature
@@ -19,11 +19,13 @@ Feature: Comparing values to values of attributes of entries within the director
  Scenario: Can asynchronously compare an attribute on an entry within the directory
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with default authentication to the directory
-   And a test container has been created
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
+   And the bind result is LDAP_SUCCESS
+   When a test container has been created
    And I've asynchronously added a new entry to the directory
-   And I've asynchronously compared to an attribute on the new entry
    Then after waiting for all results, the new entry result message type is LDAP_RES_ADD
    And the new entry result is LDAP_SUCCESS
-   And after waiting for all results, the new entry comparison result message type is LDAP_RES_COMPARE
+   When I've asynchronously compared to an attribute on the new entry
+   Then after waiting for all results, the new entry comparison result message type is LDAP_RES_COMPARE
    And the new entry comparison result is LDAP_COMPARE_TRUE
    And the test container has been deleted

--- a/t/features/delete.feature
+++ b/t/features/delete.feature
@@ -19,11 +19,13 @@ Feature: Deleting entries from the directory
  Scenario: Can asynchronously remove an entry from the directory
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with default authentication to the directory
-   And a test container has been created
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
+   And the bind result is LDAP_SUCCESS
+   When a test container has been created
    And I've asynchronously added a new entry to the directory
-   And I've asynchronously deleted the new entry from the directory
    Then after waiting for all results, the new entry result message type is LDAP_RES_ADD
    And the new entry result is LDAP_SUCCESS
-   And after waiting for all results, the delete entry result message type is LDAP_RES_DELETE
+   When I've asynchronously deleted the new entry from the directory
+   Then after waiting for all results, the delete entry result message type is LDAP_RES_DELETE
    And the delete entry result is LDAP_SUCCESS
    And the test container has been deleted

--- a/t/features/extended_operations.feature
+++ b/t/features/extended_operations.feature
@@ -29,7 +29,9 @@ Feature: Executing extended operations against the directory
  Scenario: Can asynchronously match identities retrieved with native whoami and using extended operations with anonymous authentication
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with anonymous authentication to the directory
-   And I've asynchronously queried the directory for my identity
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
+   And the bind result is LDAP_SUCCESS
+   When I've asynchronously queried the directory for my identity
    And I've asynchronously issued a whoami extended operation to the directory
    Then after waiting for all results, the identity result message type is LDAP_RES_EXTENDED
    And the identity result is LDAP_SUCCESS
@@ -41,7 +43,9 @@ Feature: Executing extended operations against the directory
  Scenario: Can asynchronously match identities retrieved with native whoami and using extended operations with simple authentication
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with simple authentication to the directory
-   And I've asynchronously queried the directory for my identity
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
+   And the bind result is LDAP_SUCCESS
+   When I've asynchronously queried the directory for my identity
    And I've asynchronously issued a whoami extended operation to the directory
    Then after waiting for all results, the identity result message type is LDAP_RES_EXTENDED
    And the identity result is LDAP_SUCCESS

--- a/t/features/modify.feature
+++ b/t/features/modify.feature
@@ -43,41 +43,47 @@ Feature: Updating attributes of entries within the directory
  Scenario: Can asynchronously add a new attribute to an entry within the directory
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with default authentication to the directory
-   And a test container has been created
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
+   And the bind result is LDAP_SUCCESS
+   When a test container has been created
    And I've asynchronously added a new entry to the directory
-   And I've asynchronously added a new attribute to the new entry
    Then after waiting for all results, the new entry result message type is LDAP_RES_ADD
    And the new entry result is LDAP_SUCCESS
-   And after waiting for all results, the new attribute result message type is LDAP_RES_MODIFY
+   When I've asynchronously added a new attribute to the new entry
+   Then after waiting for all results, the new attribute result message type is LDAP_RES_MODIFY
    And the new attribute result is LDAP_SUCCESS
    And the test container has been deleted
 
  Scenario: Can asynchronously modify an attribute on an entry within the directory
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with default authentication to the directory
-   And a test container has been created
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
+   And the bind result is LDAP_SUCCESS
+   When a test container has been created
    And I've asynchronously added a new entry to the directory
-   And I've asynchronously added a new attribute to the new entry
-   And I've asynchronously modified the new attribute on the new entry
    Then after waiting for all results, the new entry result message type is LDAP_RES_ADD
    And the new entry result is LDAP_SUCCESS
-   And after waiting for all results, the new attribute result message type is LDAP_RES_MODIFY
+   When I've asynchronously added a new attribute to the new entry
+   Then after waiting for all results, the new attribute result message type is LDAP_RES_MODIFY
    And the new attribute result is LDAP_SUCCESS
-   And after waiting for all results, the modified attribute result message type is LDAP_RES_MODIFY
+   When I've asynchronously modified the new attribute on the new entry
+   Then after waiting for all results, the modified attribute result message type is LDAP_RES_MODIFY
    And the modified attribute result is LDAP_SUCCESS
    And the test container has been deleted
 
  Scenario: Can asynchronously remove an attribute on an entry within the directory
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with default authentication to the directory
-   And a test container has been created
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
+   And the bind result is LDAP_SUCCESS
+   When a test container has been created
    And I've asynchronously added a new entry to the directory
-   And I've asynchronously added a new attribute to the new entry
-   And I've asynchronously removed the new attribute from the new entry
    Then after waiting for all results, the new entry result message type is LDAP_RES_ADD
    And the new entry result is LDAP_SUCCESS
-   And after waiting for all results, the new attribute result message type is LDAP_RES_MODIFY
+   When I've asynchronously added a new attribute to the new entry
+   Then after waiting for all results, the new attribute result message type is LDAP_RES_MODIFY
    And the new attribute result is LDAP_SUCCESS
-   And after waiting for all results, the removed attribute result message type is LDAP_RES_MODIFY
+   When I've asynchronously removed the new attribute from the new entry
+   Then after waiting for all results, the removed attribute result message type is LDAP_RES_MODIFY
    And the removed attribute result is LDAP_SUCCESS
    And the test container has been deleted

--- a/t/features/rename.feature
+++ b/t/features/rename.feature
@@ -21,14 +21,16 @@ Feature: Renaming entries within the directory
  Scenario: Can asynchronously rename an entry within the directory
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with default authentication to the directory
-   And a test container has been created
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
+   And the bind result is LDAP_SUCCESS
+   When a test container has been created
    And I've asynchronously added a new entry to the directory
    And I've asynchronously added a new container to the directory
-   And I've asynchronously moved the new entry to the new container
    Then after waiting for all results, the new entry result message type is LDAP_RES_ADD
    And the new entry result is LDAP_SUCCESS
    And after waiting for all results, the new container result message type is LDAP_RES_ADD
    And the new container result is LDAP_SUCCESS
-   And after waiting for all results, the rename entry result message type is LDAP_RES_MODDN
+   When I've asynchronously moved the new entry to the new container
+   Then after waiting for all results, the rename entry result message type is LDAP_RES_MODDN
    And the rename entry result is LDAP_SUCCESS
    And the test container has been deleted

--- a/t/features/search.feature
+++ b/t/features/search.feature
@@ -16,7 +16,9 @@ Feature: Searching the directory
  Scenario: Can asynchronously find objects that exist within the directory
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with default authentication to the directory
-   And I've asynchronously searched for records with scope LDAP_SCOPE_SUBTREE
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
+   And the bind result is LDAP_SUCCESS
+   When I've asynchronously searched for records with scope LDAP_SCOPE_SUBTREE
    Then after waiting for all results, the search result message type is LDAP_RES_SEARCH_RESULT 
    And the search result is LDAP_SUCCESS
    And the search count matches
@@ -31,7 +33,9 @@ Feature: Searching the directory
  Scenario: Can asynchronously find objects that exist within the directory with a timeout
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with default authentication to the directory
-   And I've asynchronously searched for records with scope LDAP_SCOPE_SUBTREE, with timeout 1
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
+   And the bind result is LDAP_SUCCESS
+   When I've asynchronously searched for records with scope LDAP_SCOPE_SUBTREE, with timeout 1
    Then after waiting for all results, the search result message type is LDAP_RES_SEARCH_RESULT 
    And the search result is LDAP_SUCCESS
    And the search count matches

--- a/t/features/step_definitions/general_steps.pl
+++ b/t/features/step_definitions/general_steps.pl
@@ -9,6 +9,53 @@ use Test::BDD::Cucumber::StepFile;
 
 our %TestConfig = %main::TestConfig;
 
+sub _test_container_dn {
+  return sprintf('%s,%s',
+    $TestConfig{'data'}{'test_container_dn'},
+    $TestConfig{'ldap'}{'base_dn'});
+}
+
+sub _remove_test_container {
+  my ($object) = @_;
+  my @delete_dns;
+
+  my $search_status = $object->search_s(
+    -basedn => _test_container_dn(),
+    -scope => LDAP_SCOPE_SUBTREE,
+    -filter => '(objectClass=*)',
+    -attrs => ['objectClass'],
+  );
+
+  return 1 if $search_status == LDAP_NO_SUCH_OBJECT;
+  return 0 if $search_status != LDAP_SUCCESS;
+
+  while (my $entry = $object->result_entry) {
+    push @delete_dns, $object->get_dn($entry);
+  }
+
+  for my $dn (sort { length($b) <=> length($a) } @delete_dns) {
+    my $delete_status = $object->delete_s(-dn => $dn);
+    return 0 if $delete_status != LDAP_SUCCESS
+      && $delete_status != LDAP_NO_SUCH_OBJECT;
+  }
+
+  return 1;
+}
+
+sub _wait_for_async_result {
+  my ($object, $message_id, $wait_for_all) = @_;
+  my $timeout = $TestConfig{'async_result_timeout'} || 30;
+  my $deadline = time() + $timeout;
+
+  while (time() <= $deadline) {
+    my $result = $object->result($message_id, $wait_for_all, 1);
+    return $result if defined $result;
+    return undef if defined $object->{'status'} && $object->{'status'} == -1;
+  }
+
+  return undef;
+}
+
 Given qr/a usable (\S+) class/, sub {  use_ok($1); };
 Given qr/a Net::LDAPapi object that has been connected to the (.+?)?\s?LDAP server/, sub {
   my $type = $1;
@@ -26,8 +73,12 @@ Given qr/a Net::LDAPapi object that has been connected to the (.+?)?\s?LDAP serv
 
 When qr/a test container has been created/, sub { 
   my %args = ();
+
+  my $reset_ok = _remove_test_container(S->{'object'});
+  ok($reset_ok, 'Was resetting any stale test container successful?');
+  return if !$reset_ok;
   
-  $args{'-dn'} = sprintf('%s,%s', $TestConfig{'data'}{'test_container_dn'}, $TestConfig{'ldap'}{'base_dn'});
+  $args{'-dn'} = _test_container_dn();
   $args{'-mod'} = $TestConfig{'data'}{'test_container_attributes'};
  
   my $status = S->{'object'}->add_s(%args);
@@ -36,28 +87,8 @@ When qr/a test container has been created/, sub {
 };
 
 Then qr/the test container has been deleted/, sub {
-  my %search_args = ();
-  my @delete_dns = ();
-  
-  $search_args{'-basedn'} = sprintf('%s,%s', $TestConfig{'data'}{'test_container_dn'}, $TestConfig{'ldap'}{'base_dn'});
-  $search_args{'-scope'} = LDAP_SCOPE_SUBTREE;
-  $search_args{'-filter'} = '(objectClass=*)';
-  $search_args{'-attrs'} = ['objectClass'];
-  
-  my $search_status = S->{'object'}->search_s(%search_args);
-
-  is(ldap_err2string($search_status), ldap_err2string(LDAP_SUCCESS), 'Was searching for the test container to delete successful?');
-
-  while( my $ent = S->{'object'}->result_entry) {
-    push(@delete_dns, S->{'object'}->get_dn());
-  }
-
-  foreach my $dn (sort { length($b) <=> length($a) } @delete_dns) {
-    my %delete_args = ('-dn' => $dn);
-
-    my $status = S->{'object'}->delete_s(%delete_args);
-    is(ldap_err2string($status), ldap_err2string(LDAP_SUCCESS), 'Was deleting test container contents "' . $dn . '" successful?');
-  }
+  ok(_remove_test_container(S->{'object'}),
+    'Was deleting the test container and its contents successful?');
 };
 
 Then qr/(after waiting for all results, )?the (.+) result message type is (.+)/, sub {
@@ -72,7 +103,17 @@ Then qr/(after waiting for all results, )?the (.+) result message type is (.+)/,
     isnt( S->{$test_function . '_result'}, undef, "Do we have result from $test_function?");
   
     if (is( S->{$test_function . '_async'}, 1, "Was $test_function asynchronous?")) {
-      S->{$test_function . '_result_id'} = S->{'object'}->result(S->{$test_function . '_result'}, $wait_for_all, 1);
+      S->{$test_function . '_result_id'} = _wait_for_async_result(
+        S->{'object'},
+        S->{$test_function . '_result'},
+        $wait_for_all,
+      );
+
+      return if !isnt(
+        S->{$test_function . '_result_id'},
+        undef,
+        "Did $test_function complete before the async result timeout?",
+      );
 
       is(S->{'object'}->msgtype2str(S->{'object'}->{"status"}), $desired_result, "Does expected result message type match?");  
     }

--- a/t/features/step_definitions/server_controls_steps.pl
+++ b/t/features/step_definitions/server_controls_steps.pl
@@ -104,11 +104,12 @@ Then qr/the server side sort control was successfully used/i, sub {
     }
   }
   
-  isnt($berval, undef, "Was a berval returned?");
-  
-  my $result = $sss_response->decode($berval) || ok(0, $sss_response->error);
+  return if !isnt($berval, undef, "Was a berval returned?");
 
-  is(ldap_err2string($result->{'sortResult'}), ldap_err2string(LDAP_SUCCESS), "Does server side sort result code match?");        
+  my $result = $sss_response->decode($berval);
+  return if !ok(defined $result, $sss_response->error || 'Could not decode server side sort response');
+
+  is(ldap_err2string($result->{'sortResult'}), ldap_err2string(LDAP_SUCCESS), "Does server side sort result code match?");
 };
 
 Then qr/the virtual list view control was successfully used/i, sub {
@@ -125,11 +126,12 @@ Then qr/the virtual list view control was successfully used/i, sub {
     }
   }
   
-  isnt($berval, undef, "Was a berval returned?");
-  
-  my $result = $vlv_response->decode($berval) || ok(0, $vlv_response->error);
+  return if !isnt($berval, undef, "Was a berval returned?");
 
-  is(ldap_err2string($result->{'virtualListViewResult'}), ldap_err2string(LDAP_SUCCESS), "Does virtual list view result code match?");        
+  my $result = $vlv_response->decode($berval);
+  return if !ok(defined $result, $vlv_response->error || 'Could not decode virtual list view response');
+
+  is(ldap_err2string($result->{'virtualListViewResult'}), ldap_err2string(LDAP_SUCCESS), "Does virtual list view result code match?");
 };
 
 

--- a/t/features/step_definitions/syncrepl_steps.pl
+++ b/t/features/step_definitions/syncrepl_steps.pl
@@ -11,6 +11,30 @@ our %TestConfig = %main::TestConfig;
 
 use Data::Dumper;
 
+sub _next_changed_entries_with_alarm {
+  my ($object, $message_id) = @_;
+  my $alarm_timeout = $TestConfig{'syncrepl'}{'poll_alarm_timeout'} || 10;
+  my (@entries, $error);
+
+  {
+    local $SIG{'ALRM'} = sub {
+      die "Timed out while polling the syncrepl result after ${alarm_timeout} seconds\n";
+    };
+
+    alarm($alarm_timeout);
+    my $ok = eval {
+      @entries = $object->next_changed_entries($message_id, 0, 1);
+      1;
+    };
+    $error = $@;
+    alarm(0);
+
+    die $error if !$ok;
+  }
+
+  return @entries;
+}
+
 When qr/I've started listening for changes within the directory/i, sub {
  
   S->{'listen changes_result'} = 'skipped';
@@ -24,13 +48,15 @@ When qr/I've started listening for changes within the directory/i, sub {
   $args{'-scope'} = LDAP_SCOPE_SUBTREE;
   $args{'-filter'} = '(objectClass=*)';
   $args{'-cookie'} = $TestConfig{'syncrepl'}{'cookie_dir'} . "syncrepl.$$.cookie";
-  
-#  open(COOKIE, ">" . $args{'-cookie'});
-#  close(COOKIE);
-    
+
+  open(my $cookie, '>', $args{'-cookie'})
+    or die "Cannot initialise syncrepl cookie '$args{'-cookie'}': $!";
+  close($cookie)
+    or die "Cannot close syncrepl cookie '$args{'-cookie'}': $!";
+
   S->{'listen changes_result'} = S->{'object'}->$func(%args);
-  S->{'object'}->next_changed_entries(S->{'listen changes_result'}, 0, 1);
-      
+  isnt(S->{'listen changes_result'}, undef, 'Was the syncrepl search started?');
+
 };
 
 Then qr/the changes were successfully notified/i, sub {
@@ -40,12 +66,13 @@ Then qr/the changes were successfully notified/i, sub {
   my $seen_expected = 0;
 
   my $timeout_start = time();
-  my $timeout_length = 5;
-  
+  my $timeout_length = $TestConfig{'syncrepl'}{'notification_timeout'} || 30;
+
   while(!$seen_expected) {
     if ((time() - $timeout_start) > $timeout_length) { last; }
-    
-    while(my @entries = S->{'object'}->next_changed_entries(S->{'listen changes_result'}, 0, 1)) {
+
+    while(my @entries = _next_changed_entries_with_alarm(
+      S->{'object'}, S->{'listen changes_result'})) {
       foreach my $entry (@entries) {
                     
         my $entry_dn = S->{'object'}->get_dn($entry->{'entry'});
@@ -57,8 +84,11 @@ Then qr/the changes were successfully notified/i, sub {
       }
     }
   }
-  
+
   ok($seen_expected, 'Have we seen a notification for an expected DN?');
+};
+
+Then qr/the persistent syncrepl search was successfully cancelled/i, sub {
 
   my %args;
   
@@ -76,6 +106,7 @@ ASN
   my $cancel_status = S->{'object'}->extended_operation_s(%args);
   is(ldap_err2string($cancel_status), ldap_err2string(LDAP_SUCCESS), 'Was cancelling the sync successful?');
   S->{'object'}->{'entry'} = 0;
+  unlink($TestConfig{'syncrepl'}{'cookie_dir'} . "syncrepl.$$.cookie");
 };
 
 1;

--- a/t/features/syncrepl_cancel.feature
+++ b/t/features/syncrepl_cancel.feature
@@ -1,12 +1,12 @@
-Feature: Receiving post-subscription changes with syncrepl
+Feature: Cancelling a persistent syncrepl search
  As a OpenLDAP directory consumer
- I want to ensure that I can be notified of changes to entries within the directory
- In order to act quickly on changes
+ I want to ensure that I can cancel a persistent syncrepl search
+ In order to release listener resources cleanly
 
  Background:
    Given a usable Net::LDAPapi class
 
- Scenario: Can receive post-subscription changes within the directory
+ Scenario: Can cancel a persistent syncrepl search
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've bound with default authentication to the directory
    And a test container has been created
@@ -18,3 +18,5 @@ Feature: Receiving post-subscription changes with syncrepl
    And the new container result is LDAP_SUCCESS
    And the delete entry result is LDAP_SUCCESS
    And the changes were successfully notified
+   And the persistent syncrepl search was successfully cancelled
+   And the test container has been deleted

--- a/t/features/whoami.feature
+++ b/t/features/whoami.feature
@@ -33,29 +33,29 @@ Feature: Querying the directory for my identity
  Scenario: Can asynchronously query identity with anonymous authentication
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with anonymous authentication to the directory
-   And I've asynchronously queried the directory for my identity
-   Then the bind result message type is LDAP_RES_BIND
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
    And the bind result is LDAP_SUCCESS
-   And after waiting for all results, the identity result message type is LDAP_RES_EXTENDED
+   When I've asynchronously queried the directory for my identity
+   Then after waiting for all results, the identity result message type is LDAP_RES_EXTENDED
    And the identity result is LDAP_SUCCESS
    And the identity matches
 
  Scenario: Can asynchronously query identity with simple authentication
    Given a Net::LDAPapi object that has been connected to the LDAP server
    When I've asynchronously bound with simple authentication to the directory
-   And I've asynchronously queried the directory for my identity
-   Then the bind result message type is LDAP_RES_BIND
+   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
    And the bind result is LDAP_SUCCESS
-   And after waiting for all results, the identity result message type is LDAP_RES_EXTENDED
+   When I've asynchronously queried the directory for my identity
+   Then after waiting for all results, the identity result message type is LDAP_RES_EXTENDED
    And the identity result is LDAP_SUCCESS
    And the identity matches
 
 # Scenario: Can asynchronously query identity with sasl authentication
 #   Given a Net::LDAPapi object that has been connected to the ldapi LDAP server
 #   When I've asynchronously bound with sasl authentication to the directory
-#   And I've asynchronously queried the directory for my identity
-#   Then the bind result message type is LDAP_RES_BIND
+#   Then after waiting for all results, the bind result message type is LDAP_RES_BIND
 #   And the bind result is LDAP_SUCCESS
-#   And after waiting for all results, the identity result message type is LDAP_RES_EXTENDED
+#   When I've asynchronously queried the directory for my identity
+#   Then after waiting for all results, the identity result message type is LDAP_RES_EXTENDED
 #   And the identity result is LDAP_SUCCESS
 #   And the identity matches

--- a/t/test-config.pl
+++ b/t/test-config.pl
@@ -80,8 +80,11 @@ our %TestConfig = (
   },
   'syncrepl' => {
     'enabled' => 1,
-    'cookie_dir' => '/tmp/'  
+    'cookie_dir' => '/tmp/',
+    'notification_timeout' => 30,
+    'poll_alarm_timeout' => 10,
   },
+  'async_result_timeout' => 30,
   'server_controls' => {
     'sss' => [
       {


### PR DESCRIPTION
  - Add completion barriers before dependent asynchronous LDAP operations.
  - Reset and remove the shared test container deterministically between scenarios.
  - Split SyncRepl notification and cancellation coverage into independent features.
  - Bound SyncRepl waits and harden result/control handling to avoid cascade failures.